### PR TITLE
Allow jail actions of either format

### DIFF
--- a/templates/default/jail.conf.erb
+++ b/templates/default/jail.conf.erb
@@ -94,7 +94,11 @@ enabled = <%= param['enabled'] %>
 <% end %>
 <% end %>
 <% if param['action'] %>
+<% if param['action'] =~ /action_/ %>
 action = %(<%= param['action'] %>)s
+<% else %>
+action = <%= param['action'] %>
+<% end %>
 <% end %>
 
 <% end %>


### PR DESCRIPTION
Although the [fail2ban documentation](http://www.fail2ban.org/wiki/index.php/MANUAL_0_8#Actions) is rather light, I've empirically determined that jail actions can have either of two forms:
1. Traditional actions, like:```action = iptables-multiport```
2. [Action shortcuts](https://github.com/fail2ban/fail2ban/blob/master/config/jail.conf#L145-170), like:```action = %(action_mw)s```

However, this cookbook presumes that all actions will be action shortcuts. This pull request generalizes slightly and permits either form. Action shortcuts are detected by the presence of "action_" in the action.
